### PR TITLE
Skip static methods

### DIFF
--- a/src/Status.php
+++ b/src/Status.php
@@ -3,13 +3,13 @@
 namespace Makeable\EloquentStatus;
 
 use Exception;
-use ReflectionClass;
-use ReflectionException;
-use ReflectionMethod;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Collection;
 use JsonSerializable;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
 
 abstract class Status implements Arrayable, JsonSerializable
 {

--- a/src/Status.php
+++ b/src/Status.php
@@ -4,6 +4,7 @@ namespace Makeable\EloquentStatus;
 
 use Exception;
 use ReflectionClass;
+use ReflectionException;
 use ReflectionMethod;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Query\Builder;
@@ -72,6 +73,7 @@ abstract class Status implements Arrayable, JsonSerializable
 
     /**
      * @return Collection
+     * @throws ReflectionException
      */
     public static function all()
     {

--- a/tests/Feature/BaseStatusTest.php
+++ b/tests/Feature/BaseStatusTest.php
@@ -15,6 +15,18 @@ class BaseStatusTest extends TestCase
         $this->assertTrue($statuses->first() instanceof OrderStatus);
     }
 
+    public function test_it_skips_static_methods()
+    {
+        $this->expectException(InvalidStatusException::class);
+        new OrderStatus('static method to skip');
+    }
+
+    public function test_it_skips_private_methods()
+    {
+        $this->expectException(InvalidStatusException::class);
+        new OrderStatus('private method to skip');
+    }
+
     public function test_it_validates_statuses()
     {
         $this->assertTrue(OrderStatus::validate('accepted'));

--- a/tests/Stubs/OrderStatus.php
+++ b/tests/Stubs/OrderStatus.php
@@ -33,4 +33,20 @@ class OrderStatus extends Status
     {
         return $query->where('status', 0);
     }
+
+    /**
+     * @return void
+     */
+    private function privateMethodToIgnore()
+    {
+        //
+    }
+
+    /**
+     * @return void
+     */
+    public static function staticMethodToIgnore()
+    {
+        //
+    }
 }


### PR DESCRIPTION
This allows you to define a static method in the status class. Usage case: we use badges in our application and like to map the status directly to the labels & badge colors in the status class. This enabled us to add a static method which isn't executed as a seperate status.

For instance:

```
<?php

namespace App\Statuses;

class UserStatus extends AbstractStatus
{
    public function active($query)
    {
        return $query
            ->whereNotNull('approved_at');
    }

    // Not a status method
    public static function statuses()
    {
        return [
            'active' => ['badge' => 'success', 'label' => 'Active'],
        ];
    }
}

```