### PR TITLE
Add mixed return type to jsonSerialize for Status

### DIFF
--- a/src/Status.php
+++ b/src/Status.php
@@ -60,7 +60,7 @@ abstract class Status implements Arrayable, JsonSerializable
     /**
      * @return string
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }


### PR DESCRIPTION
Fixes the following deprecation error: `Return type of Makeable\EloquentStatus\Status::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`