### PR TITLE
Fix Laravel 13 workflow in PR #29

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,17 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2, 8.3, 8.4]
-        laravel: ['10.*', '11.*', '12.*']
+        laravel: ['10.*', '11.*', '12.*', '13.*']
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
           - laravel: 11.*
             php: 8.1
           - laravel: 12.*
             php: 8.1
+          - laravel: 13.*
+            php: 8.1
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
         laravel: ['10.*', '11.*', '12.*', '13.*']
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "makeabledk/laravel-querykit": "^3.0|^4.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "makeabledk/laravel-querykit": "^3.0|^4.0"
     },
     "require-dev": {
-        "laravel/laravel": "^10.3.3|^11.0.5|^12.0",
+        "laravel/laravel": "^10.3.3|^11.0.5|^12.0|^13.0",
         "phpunit/phpunit": "^10.5.17|^11.0"
     },
     "autoload-dev": {


### PR DESCRIPTION
## Summary\n- add  to dev dependencies\n- fix the Laravel 13 CI jobs in the existing support work\n\n## Why\nThe Laravel 13 workflow jobs fail during dependency resolution because  still restricts  to 10/11/12, while the CI matrix asks Composer to install .\n\n## Verification\n- \n- \n- PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.18
Configuration: /tmp/eloquent-status-SNFhOi/repo/phpunit.xml

.................                                                 17 / 17 (100%)

Time: 00:00.270, Memory: 30.00 MB

OK, but there were issues!
Tests: 17, Assertions: 28, PHPUnit Deprecations: 3.